### PR TITLE
Allow bytestring-0.11

### DIFF
--- a/cryptohash-sha256.cabal
+++ b/cryptohash-sha256.cabal
@@ -79,7 +79,7 @@ library
                      Unsafe
 
   build-depends:     base             >= 4.5   && < 4.15
-                   , bytestring       >= 0.9.2 && < 0.11
+                   , bytestring       >= 0.9.2 && < 0.12
 
   ghc-options:       -Wall
 

--- a/src/Crypto/Hash/SHA256.hs
+++ b/src/Crypto/Hash/SHA256.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP          #-}
 {-# LANGUAGE Trustworthy  #-}
 
 -- |
@@ -92,7 +93,7 @@ module Crypto.Hash.SHA256
 import           Data.Bits                (xor)
 import           Data.ByteString          (ByteString)
 import qualified Data.ByteString          as B
-import           Data.ByteString.Internal (ByteString (PS), create,
+import           Data.ByteString.Internal (ByteString (..), create,
                                            createAndTrim, mallocByteString,
                                            memcpy, toForeignPtr)
 import qualified Data.ByteString.Lazy     as L
@@ -136,7 +137,11 @@ create' :: Int -> (Ptr Word8 -> IO a) -> IO (ByteString,a)
 create' l f = do
     fp <- mallocByteString l
     x <- withForeignPtr fp $ \p -> f p
+#if MIN_VERSION_bytestring(0,11,0)
+    let bs = BS fp l
+#else
     let bs = PS fp 0 l
+#endif
     return $! x `seq` bs `seq` (bs,x)
 
 copyCtx :: Ptr Ctx -> Ptr Ctx -> IO ()


### PR DESCRIPTION
This is important, because `cryptohash-sha256` is the last thing blocking `Cabal` from embracing `bytestring-0.11`, as discussed at https://github.com/haskell/cabal/pull/7051. Note that the patch matters only for GHC < 8.0; newer GHCs work fine without any changes except version bump.

CC @thoughtpolice, because you are listed as a Hackage maintainer.

[Changelog for `bytestring-0.11`](http://hackage.haskell.org/package/bytestring-0.11.0.0/changelog)