### PR TITLE
Allow base 4.15 (GHC 9)

### DIFF
--- a/cryptohash-sha256.cabal
+++ b/cryptohash-sha256.cabal
@@ -81,7 +81,7 @@ library
 
   ghc-options:       -Wall
 
-  build-depends:     base              >= 4.5 && < 4.15
+  build-depends:     base              >= 4.5 && < 4.16
 
   exposed-modules:   Crypto.Hash.SHA256
 


### PR DESCRIPTION
Tested with "cabal test" (Cabal 3.4), and it passed. Also tried "cabal run sha256sum" and it produced the right hash for "Hello world".